### PR TITLE
PR 8: JSON Page Object Models

### DIFF
--- a/poms/Claude/claude_page.py
+++ b/poms/Claude/claude_page.py
@@ -1,0 +1,238 @@
+"""
+Claude Page Object - JSON-Based POM
+
+Thin wrapper around the JSON-defined elements and operations.
+Provides type hints and additional convenience methods.
+
+Usage:
+    from poms.Claude.claude_page import ClaudePage
+
+    # With driver
+    claude = ClaudePage(driver)
+    claude.create_new_chat()
+    claude.type_message(text="Hello Claude!")
+    claude.send_message()
+    response = claude.wait_for_response()
+
+    # iPython exploration
+    from poms.Claude.claude_page import load_claude_elements
+    elements = load_claude_elements()
+    print(elements['new_chat_btn'])
+"""
+
+from pathlib import Path
+from typing import Optional, List, Any
+import json
+
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+# Import the loader - handle both installed and local development
+try:
+    from selectron.pom_loader import POMLoader, BasePOM, POMData
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+    from selectron.pom_loader import POMLoader, BasePOM, POMData
+
+
+# Path to this POM's directory
+POM_DIR = Path(__file__).parent
+
+
+def load_claude_elements() -> dict:
+    """
+    Load Claude elements for inspection (no driver needed).
+
+    Useful for iPython exploration.
+
+    Returns:
+        Dictionary mapping element IDs to element definitions
+    """
+    with open(POM_DIR / 'elements.json', 'r') as f:
+        data = json.load(f)
+    return {elem['id']: elem for elem in data.get('elements', [])}
+
+
+def load_claude_operations() -> dict:
+    """
+    Load Claude operations for inspection (no driver needed).
+
+    Returns:
+        Dictionary mapping operation names to operation definitions
+    """
+    with open(POM_DIR / 'operations.json', 'r') as f:
+        data = json.load(f)
+    return {op['name']: op for op in data.get('operations', [])}
+
+
+class ClaudePage(BasePOM):
+    """
+    Page Object for Claude AI assistant.
+
+    Extends BasePOM with Claude-specific convenience methods.
+    All operations from operations.json are available as methods.
+
+    Example:
+        claude = ClaudePage(driver)
+
+        # Use generated methods
+        claude.create_new_chat()
+        claude.type_message(text="Hello!")
+        claude.send_message()
+
+        # Or use execute_operation directly
+        claude.execute_operation('send_message')
+
+        # Access elements
+        elem = claude.find_element('chat_textarea')
+    """
+
+    def __init__(self, driver: WebDriver, timeout: float = 10.0):
+        """
+        Initialize Claude Page Object.
+
+        Args:
+            driver: WebDriver instance connected to Claude
+            timeout: Default wait timeout in seconds
+        """
+        pom_data = POMData('Claude', POM_DIR).load()
+        super().__init__(driver, pom_data, timeout)
+
+        # Switch to main Claude window if multiple handles
+        self._switch_to_claude_window()
+
+    def _switch_to_claude_window(self) -> None:
+        """Switch to the main Claude window."""
+        for handle in self._driver.window_handles:
+            self._driver.switch_to.window(handle)
+            if 'Claude' in self._driver.title:
+                return
+        # If no titled window, use last one
+        if self._driver.window_handles:
+            self._driver.switch_to.window(self._driver.window_handles[-1])
+
+    # =========================================
+    # Convenience Methods (beyond JSON ops)
+    # =========================================
+
+    def send_chat_message(self, message: str, wait_for_response: bool = True) -> Optional[str]:
+        """
+        Complete flow: type message, send, and optionally wait for response.
+
+        Args:
+            message: The message to send
+            wait_for_response: Whether to wait for Claude's response
+
+        Returns:
+            The response text if wait_for_response=True, else None
+        """
+        # Focus and type using ActionChains (Claude's ProseMirror editor)
+        container = self.find_element('chat_input_container')
+        if container:
+            self._driver.execute_script('arguments[0].click();', container)
+            ActionChains(self._driver).send_keys(message).perform()
+
+        # Click send
+        self.send_message()
+
+        if wait_for_response:
+            try:
+                self.wait_for_response()
+                return self.get_last_response_text()
+            except Exception:
+                return None
+
+        return None
+
+    def get_last_response_text(self) -> Optional[str]:
+        """Get the text content of the last assistant response."""
+        try:
+            messages = self._driver.find_elements(
+                By.CSS_SELECTOR, '[class*="assistant"], [class*="response"]'
+            )
+            if messages:
+                return messages[-1].text
+        except Exception:
+            pass
+        return None
+
+    def get_all_messages(self) -> List[dict]:
+        """
+        Get all messages in the current conversation.
+
+        Returns:
+            List of dicts with 'role' and 'content' keys
+        """
+        messages = []
+        try:
+            # Try to find user messages
+            user_msgs = self._driver.find_elements(
+                By.CSS_SELECTOR, '[class*="user"]'
+            )
+            for msg in user_msgs:
+                messages.append({'role': 'user', 'content': msg.text})
+
+            # Try to find assistant messages
+            assistant_msgs = self._driver.find_elements(
+                By.CSS_SELECTOR, '[class*="assistant"], [class*="response"]'
+            )
+            for msg in assistant_msgs:
+                messages.append({'role': 'assistant', 'content': msg.text})
+
+        except Exception:
+            pass
+
+        return messages
+
+    def is_generating(self) -> bool:
+        """Check if Claude is currently generating a response."""
+        try:
+            stop_btn = self.find_element('stop_btn')
+            return stop_btn is not None and stop_btn.is_displayed()
+        except Exception:
+            return False
+
+    def get_current_model(self) -> str:
+        """Get the currently selected model name."""
+        try:
+            model_btn = self.find_element('model_selector')
+            if model_btn:
+                return model_btn.text
+        except Exception:
+            pass
+        return "Unknown"
+
+    def search_chats(self, query: str) -> None:
+        """
+        Search for chats using the search dialog.
+
+        Args:
+            query: Search query string
+        """
+        self.open_search()
+        WebDriverWait(self._driver, 5).until(
+            EC.visibility_of_element_located(
+                (By.CSS_SELECTOR, 'input[type="search"], input')
+            )
+        )
+        search_input = self.find_element('search_input')
+        if search_input:
+            search_input.clear()
+            search_input.send_keys(query)
+
+
+# Convenience function for quick loading
+def load(driver: WebDriver, timeout: float = 10.0) -> ClaudePage:
+    """
+    Quick loader for ClaudePage.
+
+    Usage:
+        from poms.Claude import claude_page
+        claude = claude_page.load(driver)
+    """
+    return ClaudePage(driver, timeout)

--- a/poms/Claude/elements.json
+++ b/poms/Claude/elements.json
@@ -1,0 +1,216 @@
+{
+  "app_name": "Claude",
+  "version": "1.0.0",
+  "generated_at": "2026-01-03T06:00:00Z",
+  "description": "Claude AI assistant desktop application",
+  "default_timeout": 10.0,
+  "elements": [
+    {
+      "id": "sidebar_toggle",
+      "selector": {"type": "aria_label", "value": "Close sidebar"},
+      "alt_selectors": [
+        {"type": "css", "value": "button[aria-label*='sidebar']"}
+      ],
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "text": "",
+      "aria_label": "Close sidebar",
+      "confidence": 0.85
+    },
+    {
+      "id": "new_chat_btn",
+      "selector": {"type": "aria_label", "value": "New chat"},
+      "alt_selectors": [
+        {"type": "css", "value": "a[href*='/new']"},
+        {"type": "xpath", "value": "//a[@aria-label='New chat']"}
+      ],
+      "crud_type": "create",
+      "component_type": "Link",
+      "text": "New chat",
+      "aria_label": "New chat",
+      "confidence": 0.96
+    },
+    {
+      "id": "chats_link",
+      "selector": {"type": "aria_label", "value": "Chats"},
+      "alt_selectors": [
+        {"type": "css", "value": "a[href*='/recents']"}
+      ],
+      "crud_type": "navigate",
+      "component_type": "Link",
+      "text": "Chats",
+      "aria_label": "Chats",
+      "confidence": 0.90
+    },
+    {
+      "id": "projects_link",
+      "selector": {"type": "aria_label", "value": "Projects"},
+      "alt_selectors": [
+        {"type": "css", "value": "a[href*='/projects']"}
+      ],
+      "crud_type": "navigate",
+      "component_type": "Link",
+      "text": "Projects",
+      "aria_label": "Projects",
+      "confidence": 0.90
+    },
+    {
+      "id": "chat_input_container",
+      "selector": {"type": "css", "value": "[data-testid='chat-input-grid-container']"},
+      "alt_selectors": [
+        {"type": "css", "value": ".ProseMirror"},
+        {"type": "css", "value": "[contenteditable='true']"}
+      ],
+      "crud_type": "create",
+      "component_type": "TextArea",
+      "text": "",
+      "aria_label": "",
+      "confidence": 0.95
+    },
+    {
+      "id": "chat_textarea",
+      "selector": {"type": "css", "value": "textarea"},
+      "alt_selectors": [
+        {"type": "css", "value": ".ProseMirror"},
+        {"type": "css", "value": "[contenteditable='true']"}
+      ],
+      "crud_type": "create",
+      "component_type": "TextArea",
+      "text": "",
+      "aria_label": "",
+      "confidence": 0.92
+    },
+    {
+      "id": "send_btn",
+      "selector": {"type": "css", "value": "button[aria-label*='Send']"},
+      "alt_selectors": [
+        {"type": "css", "value": "button[type='submit']"},
+        {"type": "xpath", "value": "//button[contains(@aria-label, 'Send')]"}
+      ],
+      "crud_type": "create",
+      "component_type": "Button",
+      "text": "",
+      "aria_label": "Send Message",
+      "confidence": 0.95
+    },
+    {
+      "id": "stop_btn",
+      "selector": {"type": "css", "value": "button[aria-label*='Stop']"},
+      "alt_selectors": [
+        {"type": "css", "value": ".stop-button"}
+      ],
+      "crud_type": "update",
+      "component_type": "Button",
+      "text": "",
+      "aria_label": "Stop",
+      "confidence": 0.90
+    },
+    {
+      "id": "model_selector",
+      "selector": {"type": "css", "value": "button[aria-label*='model']"},
+      "alt_selectors": [
+        {"type": "css", "value": "button[class*='model']"}
+      ],
+      "crud_type": "update",
+      "component_type": "Button",
+      "text": "",
+      "aria_label": "Select model",
+      "confidence": 0.85
+    },
+    {
+      "id": "chat_mode_btn",
+      "selector": {"type": "aria_label", "value": "Chat"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "text": "Chat",
+      "aria_label": "Chat",
+      "confidence": 0.90
+    },
+    {
+      "id": "code_mode_btn",
+      "selector": {"type": "aria_label", "value": "Code"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "text": "Code",
+      "aria_label": "Code",
+      "confidence": 0.90
+    },
+    {
+      "id": "search_input",
+      "selector": {"type": "css", "value": "input[type='search'], input[placeholder*='Search']"},
+      "crud_type": "read",
+      "component_type": "TextInput",
+      "text": "",
+      "aria_label": "Search",
+      "confidence": 0.85
+    },
+    {
+      "id": "message_container",
+      "selector": {"type": "css", "value": "[class*='message'], [data-message]"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "text": "",
+      "aria_label": "",
+      "confidence": 0.80
+    },
+    {
+      "id": "assistant_message",
+      "selector": {"type": "css", "value": "[class*='assistant'], [class*='response']"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "text": "",
+      "aria_label": "",
+      "confidence": 0.85
+    },
+    {
+      "id": "user_message",
+      "selector": {"type": "css", "value": "[class*='user']"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "text": "",
+      "aria_label": "",
+      "confidence": 0.80
+    },
+    {
+      "id": "copy_btn",
+      "selector": {"type": "css", "value": "[aria-label*='Copy'], .copy-button"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "text": "",
+      "aria_label": "Copy",
+      "confidence": 0.85
+    },
+    {
+      "id": "settings_menu",
+      "selector": {"type": "css", "value": "[aria-label*='Settings'], [aria-label*='settings']"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "text": "",
+      "aria_label": "Settings",
+      "confidence": 0.85
+    },
+    {
+      "id": "conversation_list",
+      "selector": {"type": "css", "value": "[data-conversation], .conversation-item"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "text": "",
+      "aria_label": "",
+      "confidence": 0.80
+    },
+    {
+      "id": "root",
+      "selector": {"type": "id", "value": "root"},
+      "alt_selectors": [
+        {"type": "css", "value": "#root"},
+        {"type": "css", "value": "body"}
+      ],
+      "crud_type": "read",
+      "component_type": "Element",
+      "text": "",
+      "aria_label": "",
+      "confidence": 1.0,
+      "metadata": {"description": "Root application container"}
+    }
+  ]
+}

--- a/poms/Claude/operations.json
+++ b/poms/Claude/operations.json
@@ -1,0 +1,135 @@
+{
+  "app_name": "Claude",
+  "version": "1.0.0",
+  "operations": [
+    {
+      "name": "create_new_chat",
+      "element_id": "new_chat_btn",
+      "action": "click",
+      "description": "Create a new chat conversation",
+      "wait_after": 0.5,
+      "post_condition": "lambda driver: driver.find_elements(By.CSS_SELECTOR, '[data-testid=\"chat-input-grid-container\"], textarea')"
+    },
+    {
+      "name": "navigate_to_chats",
+      "element_id": "chats_link",
+      "action": "click",
+      "description": "Navigate to the chats/recents list",
+      "wait_after": 0.3
+    },
+    {
+      "name": "navigate_to_projects",
+      "element_id": "projects_link",
+      "action": "click",
+      "description": "Navigate to the projects list",
+      "wait_after": 0.3
+    },
+    {
+      "name": "toggle_sidebar",
+      "element_id": "sidebar_toggle",
+      "action": "click",
+      "description": "Toggle the sidebar open/closed",
+      "wait_after": 0.2
+    },
+    {
+      "name": "focus_chat_input",
+      "element_id": "chat_input_container",
+      "action": "click",
+      "description": "Focus the chat input field"
+    },
+    {
+      "name": "type_message",
+      "element_id": "chat_textarea",
+      "action": "type",
+      "description": "Type a message in the chat input (use text='your message')",
+      "params": {"text": ""}
+    },
+    {
+      "name": "send_message",
+      "element_id": "send_btn",
+      "action": "click",
+      "description": "Click the send button to send the current message",
+      "wait_after": 0.5
+    },
+    {
+      "name": "stop_response",
+      "element_id": "stop_btn",
+      "action": "click",
+      "description": "Stop the current response generation"
+    },
+    {
+      "name": "wait_for_response",
+      "element_id": "send_btn",
+      "action": "wait_clickable",
+      "description": "Wait for Claude to finish responding (send button becomes clickable)",
+      "params": {"timeout": 60.0}
+    },
+    {
+      "name": "select_model",
+      "element_id": "model_selector",
+      "action": "click",
+      "description": "Open the model selector dropdown"
+    },
+    {
+      "name": "switch_to_chat_mode",
+      "element_id": "chat_mode_btn",
+      "action": "click",
+      "description": "Switch to Chat mode"
+    },
+    {
+      "name": "switch_to_code_mode",
+      "element_id": "code_mode_btn",
+      "action": "click",
+      "description": "Switch to Code mode"
+    },
+    {
+      "name": "open_search",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open the search dialog (Cmd+K)",
+      "shortcut_keys": ["COMMAND", "k"],
+      "wait_after": 0.3
+    },
+    {
+      "name": "open_settings",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open settings (Cmd+,)",
+      "shortcut_keys": ["COMMAND", ","],
+      "wait_after": 0.3
+    },
+    {
+      "name": "new_chat_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Create new chat via keyboard shortcut (Cmd+N)",
+      "shortcut_keys": ["COMMAND", "n"],
+      "wait_after": 0.5
+    },
+    {
+      "name": "copy_last_response",
+      "element_id": "copy_btn",
+      "action": "click",
+      "description": "Copy the last response to clipboard"
+    },
+    {
+      "name": "get_last_response",
+      "element_id": "assistant_message",
+      "action": "get_text",
+      "description": "Get the text of the last assistant response"
+    },
+    {
+      "name": "read_conversation_list",
+      "element_id": "conversation_list",
+      "action": "get_text",
+      "description": "Read the conversation list items"
+    },
+    {
+      "name": "wait_page_load",
+      "element_id": "root",
+      "action": "wait_visible",
+      "description": "Wait for the page to load",
+      "params": {"timeout": 10.0}
+    }
+  ]
+}

--- a/poms/Cursor/cursor_page.py
+++ b/poms/Cursor/cursor_page.py
@@ -1,0 +1,332 @@
+"""
+Cursor Page Object - JSON-Based POM
+
+Thin wrapper around the JSON-defined elements and operations.
+Provides type hints and additional convenience methods.
+
+Usage:
+    from poms.Cursor.cursor_page import CursorPage
+
+    # With driver
+    cursor = CursorPage(driver)
+    cursor.open_command_palette()
+    cursor.create_new_chat()
+    cursor.toggle_ai_pane()
+
+    # iPython exploration
+    from poms.Cursor.cursor_page import load_cursor_elements
+    elements = load_cursor_elements()
+    print(elements['new_chat_btn'])
+"""
+
+from pathlib import Path
+from typing import Optional, List, Any
+import json
+import time
+
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+# Import the loader
+try:
+    from selectron.pom_loader import POMLoader, BasePOM, POMData
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+    from selectron.pom_loader import POMLoader, BasePOM, POMData
+
+
+# Path to this POM's directory
+POM_DIR = Path(__file__).parent
+
+
+def load_cursor_elements() -> dict:
+    """
+    Load Cursor elements for inspection (no driver needed).
+
+    Returns:
+        Dictionary mapping element IDs to element definitions
+    """
+    with open(POM_DIR / 'elements.json', 'r') as f:
+        data = json.load(f)
+    return {elem['id']: elem for elem in data.get('elements', [])}
+
+
+def load_cursor_operations() -> dict:
+    """
+    Load Cursor operations for inspection (no driver needed).
+
+    Returns:
+        Dictionary mapping operation names to operation definitions
+    """
+    with open(POM_DIR / 'operations.json', 'r') as f:
+        data = json.load(f)
+    return {op['name']: op for op in data.get('operations', [])}
+
+
+class CursorPage(BasePOM):
+    """
+    Page Object for Cursor AI-powered IDE.
+
+    Extends BasePOM with Cursor-specific convenience methods.
+    All operations from operations.json are available as methods.
+
+    Example:
+        cursor = CursorPage(driver)
+
+        # Use AI features
+        cursor.toggle_ai_pane()
+        cursor.create_new_chat()
+
+        # Navigation
+        cursor.open_command_palette()
+        cursor.open_quick_open()
+
+        # Editor
+        cursor.save_file()
+        cursor.find_in_file()
+    """
+
+    def __init__(self, driver: WebDriver, timeout: float = 10.0):
+        """
+        Initialize Cursor Page Object.
+
+        Args:
+            driver: WebDriver instance connected to Cursor
+            timeout: Default wait timeout in seconds
+        """
+        pom_data = POMData('Cursor', POM_DIR).load()
+        super().__init__(driver, pom_data, timeout)
+
+        # Switch to main Cursor window
+        self._switch_to_cursor_window()
+
+    def _switch_to_cursor_window(self) -> None:
+        """Switch to the main Cursor window."""
+        for handle in self._driver.window_handles:
+            self._driver.switch_to.window(handle)
+            if 'Cursor' in self._driver.title or '.py' in self._driver.title or '.ts' in self._driver.title:
+                return
+        if self._driver.window_handles:
+            self._driver.switch_to.window(self._driver.window_handles[-1])
+
+    # =========================================
+    # Convenience Methods
+    # =========================================
+
+    def run_command(self, command_name: str) -> None:
+        """
+        Run a command by name using the command palette.
+
+        Args:
+            command_name: Name of the command to run
+        """
+        self.open_command_palette()
+        time.sleep(0.3)
+
+        # Type in the command palette
+        try:
+            input_el = self._driver.find_element(By.CSS_SELECTOR, '.quick-input-widget input')
+            input_el.clear()
+            input_el.send_keys(command_name)
+            time.sleep(0.3)
+            input_el.send_keys(Keys.ENTER)
+        except Exception:
+            pass
+
+    def open_file(self, filename: str) -> None:
+        """
+        Open a file using quick open.
+
+        Args:
+            filename: Name or path of the file to open
+        """
+        self.open_quick_open()
+        time.sleep(0.3)
+
+        try:
+            input_el = self._driver.find_element(By.CSS_SELECTOR, '.quick-input-widget input')
+            input_el.clear()
+            input_el.send_keys(filename)
+            time.sleep(0.3)
+            input_el.send_keys(Keys.ENTER)
+        except Exception:
+            pass
+
+    def type_in_editor(self, text: str) -> None:
+        """
+        Type text into the active editor.
+
+        Args:
+            text: Text to type
+        """
+        editor = self.find_element('editor_textarea')
+        if editor:
+            editor.click()
+            ActionChains(self._driver).send_keys(text).perform()
+
+    def get_active_tab_name(self) -> Optional[str]:
+        """
+        Get the name of the currently active editor tab.
+
+        Returns:
+            Active tab name or None
+        """
+        try:
+            active_tab = self.find_element('editor_tab_active')
+            if active_tab:
+                return active_tab.get_attribute('aria-label')
+        except Exception:
+            pass
+        return None
+
+    def get_open_tabs(self) -> List[str]:
+        """
+        Get list of open editor tabs.
+
+        Returns:
+            List of tab names
+        """
+        tabs = self._driver.find_elements(By.CSS_SELECTOR, '.tab[role="tab"]')
+        return [tab.get_attribute('aria-label') or tab.text for tab in tabs]
+
+    def get_errors_count(self) -> int:
+        """
+        Get the number of errors shown in the status bar.
+
+        Returns:
+            Number of errors
+        """
+        try:
+            errors_el = self.find_element('errors_warnings')
+            if errors_el:
+                # Parse "Errors: X, Warnings: Y" format
+                label = errors_el.get_attribute('aria-label') or ''
+                if 'Errors:' in label:
+                    parts = label.split(',')
+                    for part in parts:
+                        if 'Errors:' in part:
+                            return int(part.split(':')[1].strip())
+        except Exception:
+            pass
+        return 0
+
+    def get_warnings_count(self) -> int:
+        """
+        Get the number of warnings shown in the status bar.
+
+        Returns:
+            Number of warnings
+        """
+        try:
+            errors_el = self.find_element('errors_warnings')
+            if errors_el:
+                label = errors_el.get_attribute('aria-label') or ''
+                if 'Warnings:' in label:
+                    parts = label.split(',')
+                    for part in parts:
+                        if 'Warnings:' in part:
+                            return int(part.split(':')[1].strip())
+        except Exception:
+            pass
+        return 0
+
+    def get_workspace_name(self) -> Optional[str]:
+        """
+        Get the current workspace name.
+
+        Returns:
+            Workspace name or None
+        """
+        try:
+            workspace_el = self.find_element('workspace_indicator')
+            if workspace_el:
+                label = workspace_el.get_attribute('aria-label') or ''
+                if 'Workspace:' in label:
+                    return label.replace('Workspace:', '').strip()
+        except Exception:
+            pass
+        return None
+
+    def is_ai_pane_visible(self) -> bool:
+        """Check if the AI pane is currently visible."""
+        try:
+            ai_toggle = self.find_element('toggle_ai_pane')
+            if ai_toggle:
+                classes = ai_toggle.get_attribute('class') or ''
+                return 'checked' in classes
+        except Exception:
+            pass
+        return False
+
+    def is_terminal_visible(self) -> bool:
+        """Check if the terminal panel is visible."""
+        try:
+            terminal_section = self.find_element('terminal_section')
+            return terminal_section is not None and terminal_section.is_displayed()
+        except Exception:
+            return False
+
+    def get_file_list(self) -> List[str]:
+        """
+        Get list of files visible in the explorer.
+
+        Returns:
+            List of file names
+        """
+        files = self._driver.find_elements(By.CSS_SELECTOR, '.monaco-list-row[role="treeitem"]')
+        return [f.get_attribute('aria-label') or f.text for f in files if f.text]
+
+    def click_file(self, filename: str) -> bool:
+        """
+        Click a file in the explorer by name.
+
+        Args:
+            filename: Name of the file to click
+
+        Returns:
+            True if file was found and clicked
+        """
+        files = self._driver.find_elements(By.CSS_SELECTOR, '.monaco-list-row[role="treeitem"]')
+        for f in files:
+            label = f.get_attribute('aria-label') or f.text
+            if label == filename or filename in label:
+                f.click()
+                return True
+        return False
+
+    def send_chat_message(self, message: str) -> None:
+        """
+        Send a message in the AI chat.
+
+        Args:
+            message: Message to send
+        """
+        # Ensure AI pane is visible
+        if not self.is_ai_pane_visible():
+            self.toggle_ai_pane()
+            time.sleep(0.3)
+
+        # Find composer and type
+        composer = self.find_element('composer_bar')
+        if composer:
+            composer.click()
+            ActionChains(self._driver).send_keys(message).perform()
+            ActionChains(self._driver).send_keys(Keys.ENTER).perform()
+
+
+# Convenience function for quick loading
+def load(driver: WebDriver, timeout: float = 10.0) -> CursorPage:
+    """
+    Quick loader for CursorPage.
+
+    Usage:
+        from poms.Cursor import cursor_page
+        cursor = cursor_page.load(driver)
+    """
+    return CursorPage(driver, timeout)

--- a/poms/Cursor/elements.json
+++ b/poms/Cursor/elements.json
@@ -1,0 +1,414 @@
+{
+  "app_name": "Cursor",
+  "version": "1.0.0",
+  "generated_at": "2026-01-03T06:30:00Z",
+  "description": "Cursor AI-powered IDE",
+  "default_timeout": 10.0,
+  "element_count": 52,
+  "by_operation": {
+    "create": 8,
+    "read": 18,
+    "update": 4,
+    "navigate": 12,
+    "delete": 3,
+    "unknown": 7
+  },
+  "elements": [
+    {
+      "id": "agents_tab",
+      "selector": {"type": "css", "value": "button.segmented-tab:has-text('Agents')"},
+      "alt_selectors": [{"type": "xpath", "value": "//button[contains(@class, 'segmented-tab') and text()='Agents']"}],
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "confidence": 0.90
+    },
+    {
+      "id": "editor_tab",
+      "selector": {"type": "css", "value": "button.segmented-tab.active"},
+      "alt_selectors": [{"type": "xpath", "value": "//button[contains(@class, 'segmented-tab') and text()='Editor']"}],
+      "crud_type": "update",
+      "component_type": "Button",
+      "confidence": 0.90
+    },
+    {
+      "id": "go_back",
+      "selector": {"type": "aria_label", "value": "Go Back (⌘[)"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Go Back (⌘[)",
+      "confidence": 0.60
+    },
+    {
+      "id": "go_forward",
+      "selector": {"type": "aria_label", "value": "Go Forward (⌘])"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Go Forward (⌘])",
+      "confidence": 0.60
+    },
+    {
+      "id": "command_center",
+      "selector": {"type": "css", "value": ".command-center-center"},
+      "crud_type": "navigate",
+      "component_type": "Element",
+      "confidence": 0.85
+    },
+    {
+      "id": "quick_pick",
+      "selector": {"type": "css", "value": ".command-center-quick-pick"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "confidence": 0.85
+    },
+    {
+      "id": "toggle_primary_sidebar",
+      "selector": {"type": "aria_label", "value": "Toggle Primary Side Bar (⌘B)"},
+      "crud_type": "update",
+      "component_type": "Button",
+      "aria_label": "Toggle Primary Side Bar (⌘B)",
+      "confidence": 0.60
+    },
+    {
+      "id": "toggle_panel",
+      "selector": {"type": "aria_label", "value": "Toggle Panel (⌘J)"},
+      "crud_type": "update",
+      "component_type": "Button",
+      "aria_label": "Toggle Panel (⌘J)",
+      "confidence": 0.60
+    },
+    {
+      "id": "toggle_ai_pane",
+      "selector": {"type": "aria_label", "value": "Toggle AI Pane (⌥⌘B)"},
+      "crud_type": "update",
+      "component_type": "Button",
+      "aria_label": "Toggle AI Pane (⌥⌘B)",
+      "confidence": 0.60
+    },
+    {
+      "id": "change_layout",
+      "selector": {"type": "aria_label", "value": "Change Layout"},
+      "crud_type": "update",
+      "component_type": "Button",
+      "aria_label": "Change Layout",
+      "confidence": 0.60
+    },
+    {
+      "id": "files_explorer",
+      "selector": {"type": "aria_label", "value": "Files Explorer"},
+      "crud_type": "read",
+      "component_type": "Tree",
+      "aria_label": "Files Explorer",
+      "confidence": 0.90
+    },
+    {
+      "id": "explorer_section",
+      "selector": {"type": "css", "value": ".pane-header[aria-label*='Explorer Section']"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "confidence": 0.85
+    },
+    {
+      "id": "file_item",
+      "selector": {"type": "css", "value": ".monaco-list-row[role='treeitem']"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "confidence": 0.85
+    },
+    {
+      "id": "debug_console",
+      "selector": {"type": "aria_label", "value": "Debug Console"},
+      "crud_type": "read",
+      "component_type": "Tree",
+      "aria_label": "Debug Console",
+      "confidence": 0.60
+    },
+    {
+      "id": "debug_console_section",
+      "selector": {"type": "aria_label", "value": "Debug Console Section"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Debug Console Section",
+      "confidence": 0.60
+    },
+    {
+      "id": "editor_textarea",
+      "selector": {"type": "css", "value": "textarea.inputarea.monaco-mouse-cursor-text"},
+      "crud_type": "update",
+      "component_type": "TextArea",
+      "confidence": 0.90
+    },
+    {
+      "id": "editor_tab_active",
+      "selector": {"type": "css", "value": ".tab.active.selected[role='tab']"},
+      "crud_type": "read",
+      "component_type": "Tab",
+      "confidence": 0.90
+    },
+    {
+      "id": "close_tab",
+      "selector": {"type": "aria_label", "value": "Close (⌘W)"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Close (⌘W)",
+      "confidence": 0.60
+    },
+    {
+      "id": "split_editor",
+      "selector": {"type": "css", "value": "[aria-label*='Split Editor']"},
+      "crud_type": "create",
+      "component_type": "Button",
+      "confidence": 0.60
+    },
+    {
+      "id": "more_actions",
+      "selector": {"type": "aria_label", "value": "More Actions..."},
+      "crud_type": "read",
+      "component_type": "Button",
+      "aria_label": "More Actions...",
+      "confidence": 0.60
+    },
+    {
+      "id": "breadcrumbs",
+      "selector": {"type": "css", "value": ".monaco-breadcrumbs"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "confidence": 0.85
+    },
+    {
+      "id": "new_chat_tab",
+      "selector": {"type": "css", "value": ".composite-bar-action-tab.checked"},
+      "crud_type": "create",
+      "component_type": "Tab",
+      "confidence": 0.85
+    },
+    {
+      "id": "new_chat_btn",
+      "selector": {"type": "aria_label", "value": "New Chat"},
+      "alt_selectors": [{"type": "aria_label", "value": "New Chat (⌘T)\n[⌥] Replace Chat (⌘N)"}],
+      "crud_type": "create",
+      "component_type": "Button",
+      "aria_label": "New Chat",
+      "confidence": 0.60
+    },
+    {
+      "id": "chat_history_btn",
+      "selector": {"type": "aria_label", "value": "Show Chat History (⌥⌘')"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "aria_label": "Show Chat History (⌥⌘')",
+      "confidence": 0.60
+    },
+    {
+      "id": "chat_settings_btn",
+      "selector": {"type": "aria_label", "value": "Close, Export, Settings and More..."},
+      "crud_type": "update",
+      "component_type": "Button",
+      "aria_label": "Close, Export, Settings and More...",
+      "confidence": 0.60
+    },
+    {
+      "id": "composer_bar",
+      "selector": {"type": "css", "value": ".composer-bar"},
+      "crud_type": "create",
+      "component_type": "Element",
+      "confidence": 0.85
+    },
+    {
+      "id": "past_chats",
+      "selector": {"type": "css", "value": ".composer-below-chat-history-item"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "confidence": 0.80
+    },
+    {
+      "id": "view_all_chats",
+      "selector": {"type": "css", "value": ".composer-below-chat-history-view-all"},
+      "crud_type": "navigate",
+      "component_type": "Link",
+      "confidence": 0.85
+    },
+    {
+      "id": "problems_tab",
+      "selector": {"type": "css", "value": "[aria-label*='Problems']"},
+      "crud_type": "read",
+      "component_type": "Tab",
+      "confidence": 0.80
+    },
+    {
+      "id": "output_tab",
+      "selector": {"type": "aria_label", "value": "Output (⇧⌘U)"},
+      "crud_type": "read",
+      "component_type": "Tab",
+      "aria_label": "Output (⇧⌘U)",
+      "confidence": 0.60
+    },
+    {
+      "id": "terminal_tab",
+      "selector": {"type": "aria_label", "value": "Terminal (⌥F12)"},
+      "crud_type": "navigate",
+      "component_type": "Tab",
+      "aria_label": "Terminal (⌥F12)",
+      "confidence": 0.60
+    },
+    {
+      "id": "terminal_section",
+      "selector": {"type": "aria_label", "value": "Terminal Section"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Terminal Section",
+      "confidence": 0.60
+    },
+    {
+      "id": "ports_tab",
+      "selector": {"type": "aria_label", "value": "Ports"},
+      "crud_type": "read",
+      "component_type": "Tab",
+      "aria_label": "Ports",
+      "confidence": 0.60
+    },
+    {
+      "id": "hide_panel",
+      "selector": {"type": "aria_label", "value": "Hide Panel (⌘J)"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Hide Panel (⌘J)",
+      "confidence": 0.60
+    },
+    {
+      "id": "jupyter_variables_section",
+      "selector": {"type": "aria_label", "value": "Jupyter Variables Section"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "aria_label": "Jupyter Variables Section",
+      "confidence": 0.60
+    },
+    {
+      "id": "statusbar",
+      "selector": {"type": "id", "value": "workbench.parts.statusbar"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "confidence": 0.95
+    },
+    {
+      "id": "remote_indicator",
+      "selector": {"type": "aria_label", "value": "remote"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "remote",
+      "confidence": 0.60
+    },
+    {
+      "id": "workspace_indicator",
+      "selector": {"type": "css", "value": "[aria-label^='Workspace:']"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "confidence": 0.80
+    },
+    {
+      "id": "errors_warnings",
+      "selector": {"type": "css", "value": "[aria-label^='Errors:']"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "confidence": 0.80
+    },
+    {
+      "id": "notifications",
+      "selector": {"type": "aria_label", "value": "Notifications"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "aria_label": "Notifications",
+      "confidence": 0.60
+    },
+    {
+      "id": "live_share_btn",
+      "selector": {"type": "css", "value": "[aria-label*='Live Share']"},
+      "crud_type": "create",
+      "component_type": "Button",
+      "confidence": 0.60
+    },
+    {
+      "id": "go_live_btn",
+      "selector": {"type": "css", "value": "[aria-label*='Go Live']"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "confidence": 0.60
+    },
+    {
+      "id": "spaces_indicator",
+      "selector": {"type": "css", "value": "[aria-label^='Spaces:']"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "confidence": 0.60
+    },
+    {
+      "id": "cursor_tab_status",
+      "selector": {"type": "css", "value": ".copilot-plus-plus-status-on"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "confidence": 0.85
+    },
+    {
+      "id": "add_code_cell",
+      "selector": {"type": "aria_label", "value": "Add Code Cell (⌘⏎)"},
+      "crud_type": "create",
+      "component_type": "Button",
+      "aria_label": "Add Code Cell (⌘⏎)",
+      "confidence": 0.60
+    },
+    {
+      "id": "add_markdown_cell",
+      "selector": {"type": "aria_label", "value": "Add Markdown Cell"},
+      "crud_type": "create",
+      "component_type": "Button",
+      "aria_label": "Add Markdown Cell",
+      "confidence": 0.60
+    },
+    {
+      "id": "run_all",
+      "selector": {"type": "aria_label", "value": "Run All"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Run All",
+      "confidence": 0.60
+    },
+    {
+      "id": "restart_kernel",
+      "selector": {"type": "aria_label", "value": "Restart Kernel"},
+      "crud_type": "update",
+      "component_type": "Button",
+      "aria_label": "Restart Kernel",
+      "confidence": 0.60
+    },
+    {
+      "id": "clear_all_outputs",
+      "selector": {"type": "aria_label", "value": "Clear All Outputs"},
+      "crud_type": "delete",
+      "component_type": "Button",
+      "aria_label": "Clear All Outputs",
+      "confidence": 0.60
+    },
+    {
+      "id": "delete_cell",
+      "selector": {"type": "aria_label", "value": "Delete Cell (D D)"},
+      "crud_type": "delete",
+      "component_type": "Button",
+      "aria_label": "Delete Cell (D D)",
+      "confidence": 0.60
+    },
+    {
+      "id": "clear_notification",
+      "selector": {"type": "aria_label", "value": "Clear Notification (⌘⌫)"},
+      "crud_type": "delete",
+      "component_type": "Button",
+      "aria_label": "Clear Notification (⌘⌫)",
+      "confidence": 0.60
+    },
+    {
+      "id": "notebook_list",
+      "selector": {"type": "css", "value": ".monaco-list[aria-label*='Notebook']"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "confidence": 0.85
+    }
+  ]
+}

--- a/poms/Cursor/operations.json
+++ b/poms/Cursor/operations.json
@@ -1,0 +1,351 @@
+{
+  "app_name": "Cursor",
+  "version": "1.0.0",
+  "operations": [
+    {
+      "name": "open_command_palette",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open the command palette (Cmd+Shift+P)",
+      "shortcut_keys": ["COMMAND", "SHIFT", "p"],
+      "wait_after": 0.3,
+      "post_condition": "lambda driver: driver.find_elements(By.CSS_SELECTOR, '.quick-input-widget')"
+    },
+    {
+      "name": "open_quick_open",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open quick file search (Cmd+P)",
+      "shortcut_keys": ["COMMAND", "p"],
+      "wait_after": 0.3,
+      "post_condition": "lambda driver: driver.find_elements(By.CSS_SELECTOR, '.quick-input-widget')"
+    },
+    {
+      "name": "create_new_file",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Create a new file (Cmd+N)",
+      "shortcut_keys": ["COMMAND", "n"],
+      "wait_after": 0.5
+    },
+    {
+      "name": "save_file",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Save current file (Cmd+S)",
+      "shortcut_keys": ["COMMAND", "s"],
+      "wait_after": 0.3
+    },
+    {
+      "name": "close_tab",
+      "element_id": "close_tab",
+      "action": "click",
+      "description": "Close the current tab",
+      "wait_after": 0.3
+    },
+    {
+      "name": "close_tab_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Close current tab (Cmd+W)",
+      "shortcut_keys": ["COMMAND", "w"],
+      "wait_after": 0.3
+    },
+    {
+      "name": "go_back",
+      "element_id": "go_back",
+      "action": "click",
+      "description": "Navigate back in history"
+    },
+    {
+      "name": "go_back_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Navigate back via keyboard (Cmd+[)",
+      "shortcut_keys": ["COMMAND", "["]
+    },
+    {
+      "name": "go_forward",
+      "element_id": "go_forward",
+      "action": "click",
+      "description": "Navigate forward in history"
+    },
+    {
+      "name": "go_forward_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Navigate forward via keyboard (Cmd+])",
+      "shortcut_keys": ["COMMAND", "]"]
+    },
+    {
+      "name": "toggle_sidebar",
+      "element_id": "toggle_primary_sidebar",
+      "action": "click",
+      "description": "Toggle the primary sidebar visibility"
+    },
+    {
+      "name": "toggle_sidebar_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Toggle sidebar via keyboard (Cmd+B)",
+      "shortcut_keys": ["COMMAND", "b"]
+    },
+    {
+      "name": "toggle_panel",
+      "element_id": "toggle_panel",
+      "action": "click",
+      "description": "Toggle the bottom panel visibility"
+    },
+    {
+      "name": "toggle_panel_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Toggle panel via keyboard (Cmd+J)",
+      "shortcut_keys": ["COMMAND", "j"]
+    },
+    {
+      "name": "toggle_ai_pane",
+      "element_id": "toggle_ai_pane",
+      "action": "click",
+      "description": "Toggle the AI pane visibility"
+    },
+    {
+      "name": "toggle_ai_pane_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Toggle AI pane via keyboard (Opt+Cmd+B)",
+      "shortcut_keys": ["ALT", "COMMAND", "b"]
+    },
+    {
+      "name": "create_new_chat",
+      "element_id": "new_chat_btn",
+      "action": "click",
+      "description": "Create a new AI chat",
+      "wait_after": 0.5
+    },
+    {
+      "name": "create_new_chat_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Create new chat via keyboard (Cmd+T)",
+      "shortcut_keys": ["COMMAND", "t"],
+      "wait_after": 0.5
+    },
+    {
+      "name": "show_chat_history",
+      "element_id": "chat_history_btn",
+      "action": "click",
+      "description": "Show the chat history panel",
+      "wait_after": 0.3
+    },
+    {
+      "name": "show_chat_history_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Show chat history via keyboard (Opt+Cmd+')",
+      "shortcut_keys": ["ALT", "COMMAND", "'"],
+      "wait_after": 0.3
+    },
+    {
+      "name": "open_chat_settings",
+      "element_id": "chat_settings_btn",
+      "action": "click",
+      "description": "Open chat settings menu"
+    },
+    {
+      "name": "switch_to_agents",
+      "element_id": "agents_tab",
+      "action": "click",
+      "description": "Switch to Agents mode in AI pane"
+    },
+    {
+      "name": "switch_to_editor",
+      "element_id": "editor_tab",
+      "action": "click",
+      "description": "Switch to Editor mode in AI pane"
+    },
+    {
+      "name": "open_terminal",
+      "element_id": "terminal_tab",
+      "action": "click",
+      "description": "Open the terminal panel"
+    },
+    {
+      "name": "open_terminal_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Toggle terminal via keyboard (Ctrl+`)",
+      "shortcut_keys": ["CONTROL", "`"]
+    },
+    {
+      "name": "open_output",
+      "element_id": "output_tab",
+      "action": "click",
+      "description": "Open the output panel"
+    },
+    {
+      "name": "open_output_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Toggle output via keyboard (Shift+Cmd+U)",
+      "shortcut_keys": ["SHIFT", "COMMAND", "u"]
+    },
+    {
+      "name": "open_problems",
+      "element_id": "problems_tab",
+      "action": "click",
+      "description": "Open the problems panel"
+    },
+    {
+      "name": "hide_panel",
+      "element_id": "hide_panel",
+      "action": "click",
+      "description": "Hide the bottom panel"
+    },
+    {
+      "name": "view_all_chats",
+      "element_id": "view_all_chats",
+      "action": "click",
+      "description": "View all past chats",
+      "wait_after": 0.3
+    },
+    {
+      "name": "show_notifications",
+      "element_id": "notifications",
+      "action": "click",
+      "description": "Show the notifications panel"
+    },
+    {
+      "name": "clear_notification",
+      "element_id": "clear_notification",
+      "action": "click",
+      "description": "Clear the current notification"
+    },
+    {
+      "name": "add_code_cell",
+      "element_id": "add_code_cell",
+      "action": "click",
+      "description": "Add a new code cell in notebook"
+    },
+    {
+      "name": "add_markdown_cell",
+      "element_id": "add_markdown_cell",
+      "action": "click",
+      "description": "Add a new markdown cell in notebook"
+    },
+    {
+      "name": "run_all_cells",
+      "element_id": "run_all",
+      "action": "click",
+      "description": "Run all cells in notebook"
+    },
+    {
+      "name": "restart_kernel",
+      "element_id": "restart_kernel",
+      "action": "click",
+      "description": "Restart the Jupyter kernel"
+    },
+    {
+      "name": "clear_all_outputs",
+      "element_id": "clear_all_outputs",
+      "action": "click",
+      "description": "Clear all cell outputs in notebook"
+    },
+    {
+      "name": "delete_cell",
+      "element_id": "delete_cell",
+      "action": "click",
+      "description": "Delete the current cell"
+    },
+    {
+      "name": "open_files_explorer",
+      "element_id": "files_explorer",
+      "action": "click",
+      "description": "Focus the files explorer"
+    },
+    {
+      "name": "split_editor",
+      "element_id": "split_editor",
+      "action": "click",
+      "description": "Split the editor"
+    },
+    {
+      "name": "split_editor_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Split editor right via keyboard (Cmd+\\)",
+      "shortcut_keys": ["COMMAND", "\\"]
+    },
+    {
+      "name": "open_settings",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open settings (Cmd+,)",
+      "shortcut_keys": ["COMMAND", ","],
+      "wait_after": 0.5
+    },
+    {
+      "name": "open_keyboard_shortcuts",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open keyboard shortcuts (Cmd+K Cmd+S)",
+      "shortcut_keys": ["COMMAND", "k"],
+      "wait_after": 0.3
+    },
+    {
+      "name": "find_in_file",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open find in file (Cmd+F)",
+      "shortcut_keys": ["COMMAND", "f"],
+      "wait_after": 0.3
+    },
+    {
+      "name": "find_and_replace",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open find and replace (Cmd+Opt+F)",
+      "shortcut_keys": ["COMMAND", "ALT", "f"],
+      "wait_after": 0.3
+    },
+    {
+      "name": "search_in_workspace",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Search in workspace (Cmd+Shift+F)",
+      "shortcut_keys": ["COMMAND", "SHIFT", "f"],
+      "wait_after": 0.3
+    },
+    {
+      "name": "go_to_line",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Go to line (Ctrl+G)",
+      "shortcut_keys": ["CONTROL", "g"],
+      "wait_after": 0.3
+    },
+    {
+      "name": "go_to_symbol",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Go to symbol in file (Cmd+Shift+O)",
+      "shortcut_keys": ["COMMAND", "SHIFT", "o"],
+      "wait_after": 0.3
+    },
+    {
+      "name": "close_modal",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Close current modal/dialog (Escape)",
+      "shortcut_keys": ["ESCAPE"],
+      "wait_after": 0.2
+    },
+    {
+      "name": "wait_page_load",
+      "element_id": "statusbar",
+      "action": "wait_visible",
+      "description": "Wait for Cursor to load",
+      "params": {"timeout": 10.0}
+    }
+  ]
+}

--- a/poms/Obsidian/elements.json
+++ b/poms/Obsidian/elements.json
@@ -1,0 +1,303 @@
+{
+  "app_name": "Obsidian",
+  "version": "1.0.0",
+  "generated_at": "2026-01-03T06:00:00Z",
+  "description": "Obsidian note-taking application",
+  "default_timeout": 10.0,
+  "element_count": 76,
+  "by_operation": {
+    "create": 6,
+    "read": 31,
+    "update": 4,
+    "navigate": 5,
+    "unknown": 30
+  },
+  "elements": [
+    {
+      "id": "create_new_base",
+      "selector": {"type": "aria_label", "value": "Create new base"},
+      "crud_type": "create",
+      "component_type": "Button",
+      "aria_label": "Create new base",
+      "confidence": 0.60
+    },
+    {
+      "id": "create_new_board",
+      "selector": {"type": "aria_label", "value": "Create new board"},
+      "crud_type": "create",
+      "component_type": "Button",
+      "aria_label": "Create new board",
+      "confidence": 0.60
+    },
+    {
+      "id": "create_new_canvas",
+      "selector": {"type": "aria_label", "value": "Create new canvas"},
+      "crud_type": "create",
+      "component_type": "Button",
+      "aria_label": "Create new canvas",
+      "confidence": 0.60
+    },
+    {
+      "id": "insert_template",
+      "selector": {"type": "aria_label", "value": "Insert template"},
+      "crud_type": "create",
+      "component_type": "Button",
+      "aria_label": "Insert template",
+      "confidence": 0.60
+    },
+    {
+      "id": "create_unique_note",
+      "selector": {"type": "aria_label", "value": "Create new unique note"},
+      "crud_type": "create",
+      "component_type": "Button",
+      "aria_label": "Create new unique note",
+      "confidence": 0.60
+    },
+    {
+      "id": "new_tab",
+      "selector": {"type": "aria_label", "value": "New tab"},
+      "crud_type": "create",
+      "component_type": "Button",
+      "aria_label": "New tab",
+      "confidence": 0.60
+    },
+    {
+      "id": "quick_switcher",
+      "selector": {"type": "aria_label", "value": "Open quick switcher"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Open quick switcher",
+      "confidence": 0.60
+    },
+    {
+      "id": "graph_view",
+      "selector": {"type": "aria_label", "value": "Open graph view"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Open graph view",
+      "confidence": 0.60
+    },
+    {
+      "id": "daily_note",
+      "selector": {"type": "aria_label", "value": "Open today's daily note"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "aria_label": "Open today's daily note",
+      "confidence": 0.60
+    },
+    {
+      "id": "command_palette",
+      "selector": {"type": "aria_label", "value": "Open command palette"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Open command palette",
+      "confidence": 0.60
+    },
+    {
+      "id": "format_converter",
+      "selector": {"type": "aria_label", "value": "Open format converter"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "aria_label": "Open format converter",
+      "confidence": 0.60
+    },
+    {
+      "id": "smart_connections",
+      "selector": {"type": "aria_label", "value": "Smart Connections: Open connections view"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "aria_label": "Smart Connections: Open connections view",
+      "confidence": 0.60
+    },
+    {
+      "id": "smart_lookup",
+      "selector": {"type": "aria_label", "value": "Smart Lookup: Open lookup view"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "aria_label": "Smart Lookup: Open lookup view",
+      "confidence": 0.60
+    },
+    {
+      "id": "publish_changes",
+      "selector": {"type": "aria_label", "value": "Publish changes..."},
+      "crud_type": "update",
+      "component_type": "Button",
+      "aria_label": "Publish changes...",
+      "confidence": 0.54
+    },
+    {
+      "id": "files_tab",
+      "selector": {"type": "css", "value": ".workspace-tab-header[aria-label='Files']"},
+      "crud_type": "navigate",
+      "component_type": "Tab",
+      "aria_label": "Files",
+      "confidence": 0.48
+    },
+    {
+      "id": "search_tab",
+      "selector": {"type": "css", "value": ".workspace-tab-header[aria-label='Search']"},
+      "crud_type": "navigate",
+      "component_type": "Tab",
+      "aria_label": "Search",
+      "confidence": 0.58
+    },
+    {
+      "id": "bookmarks_tab",
+      "selector": {"type": "css", "value": ".workspace-tab-header[aria-label='Bookmarks']"},
+      "crud_type": "navigate",
+      "component_type": "Tab",
+      "aria_label": "Bookmarks",
+      "confidence": 0.36
+    },
+    {
+      "id": "backlinks_tab",
+      "selector": {"type": "css", "value": ".workspace-tab-header[aria-label='Backlinks']"},
+      "crud_type": "navigate",
+      "component_type": "Tab",
+      "aria_label": "Backlinks",
+      "confidence": 0.47
+    },
+    {
+      "id": "tags_tab",
+      "selector": {"type": "css", "value": ".workspace-tab-header[aria-label='Tags']"},
+      "crud_type": "read",
+      "component_type": "Tab",
+      "aria_label": "Tags",
+      "confidence": 0.46
+    },
+    {
+      "id": "navigate_back",
+      "selector": {"type": "aria_label", "value": "Navigate back"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Navigate back",
+      "confidence": 0.60
+    },
+    {
+      "id": "navigate_forward",
+      "selector": {"type": "aria_label", "value": "Navigate forward"},
+      "crud_type": "navigate",
+      "component_type": "Button",
+      "aria_label": "Navigate forward",
+      "confidence": 0.40
+    },
+    {
+      "id": "more_options",
+      "selector": {"type": "aria_label", "value": "More options"},
+      "crud_type": "update",
+      "component_type": "Button",
+      "aria_label": "More options",
+      "confidence": 0.55
+    },
+    {
+      "id": "change_sort_order",
+      "selector": {"type": "aria_label", "value": "Change sort order"},
+      "crud_type": "update",
+      "component_type": "Button",
+      "aria_label": "Change sort order",
+      "confidence": 0.60
+    },
+    {
+      "id": "show_search_filter",
+      "selector": {"type": "aria_label", "value": "Show search filter"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "aria_label": "Show search filter",
+      "confidence": 0.60
+    },
+    {
+      "id": "todo_list",
+      "selector": {"type": "aria_label", "value": "Todo List"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "aria_label": "Todo List",
+      "confidence": 0.60
+    },
+    {
+      "id": "all_properties",
+      "selector": {"type": "aria_label", "value": "All properties"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "aria_label": "All properties",
+      "confidence": 0.32
+    },
+    {
+      "id": "notifications_feed",
+      "selector": {"type": "aria_label", "value": "Open notifications feed"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "aria_label": "Open notifications feed",
+      "confidence": 0.60
+    },
+    {
+      "id": "quick_switcher_modal",
+      "selector": {"type": "css", "value": ".prompt"},
+      "crud_type": "read",
+      "component_type": "Modal",
+      "confidence": 0.90
+    },
+    {
+      "id": "quick_switcher_input",
+      "selector": {"type": "css", "value": ".prompt input"},
+      "crud_type": "create",
+      "component_type": "TextInput",
+      "confidence": 0.90
+    },
+    {
+      "id": "file_explorer",
+      "selector": {"type": "css", "value": ".nav-files-container"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "confidence": 0.85
+    },
+    {
+      "id": "file_item",
+      "selector": {"type": "css", "value": ".nav-file-title"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "confidence": 0.85
+    },
+    {
+      "id": "folder_item",
+      "selector": {"type": "css", "value": ".nav-folder-title"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "confidence": 0.85
+    },
+    {
+      "id": "editor",
+      "selector": {"type": "css", "value": ".cm-content, .markdown-source-view"},
+      "crud_type": "update",
+      "component_type": "TextArea",
+      "confidence": 0.90
+    },
+    {
+      "id": "workspace_tab",
+      "selector": {"type": "css", "value": ".workspace-tab-header.tappable"},
+      "crud_type": "read",
+      "component_type": "Tab",
+      "confidence": 0.85
+    },
+    {
+      "id": "active_workspace_tab",
+      "selector": {"type": "css", "value": ".workspace-tab-header.is-active, .workspace-tab-header.mod-active"},
+      "crud_type": "read",
+      "component_type": "Tab",
+      "confidence": 0.90
+    },
+    {
+      "id": "ribbon_action",
+      "selector": {"type": "css", "value": ".side-dock-ribbon-action"},
+      "crud_type": "read",
+      "component_type": "Button",
+      "confidence": 0.80
+    },
+    {
+      "id": "app_container",
+      "selector": {"type": "css", "value": ".app-container, body"},
+      "crud_type": "read",
+      "component_type": "Element",
+      "confidence": 1.0
+    }
+  ]
+}

--- a/poms/Obsidian/obsidian_page.py
+++ b/poms/Obsidian/obsidian_page.py
@@ -1,0 +1,285 @@
+"""
+Obsidian Page Object - JSON-Based POM
+
+Thin wrapper around the JSON-defined elements and operations.
+Provides type hints and additional convenience methods.
+
+Usage:
+    from poms.Obsidian.obsidian_page import ObsidianPage
+
+    # With driver
+    obsidian = ObsidianPage(driver)
+    obsidian.open_quick_switcher()
+    obsidian.search_in_switcher(text="My Note")
+    obsidian.select_first_result()
+
+    # iPython exploration
+    from poms.Obsidian.obsidian_page import load_obsidian_elements
+    elements = load_obsidian_elements()
+    print(elements['quick_switcher'])
+"""
+
+from pathlib import Path
+from typing import Optional, List, Any
+import json
+import time
+
+from selenium.webdriver.remote.webdriver import WebDriver
+from selenium.webdriver.remote.webelement import WebElement
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+# Import the loader
+try:
+    from selectron.pom_loader import POMLoader, BasePOM, POMData
+except ImportError:
+    import sys
+    sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+    from selectron.pom_loader import POMLoader, BasePOM, POMData
+
+
+# Path to this POM's directory
+POM_DIR = Path(__file__).parent
+
+
+def load_obsidian_elements() -> dict:
+    """
+    Load Obsidian elements for inspection (no driver needed).
+
+    Returns:
+        Dictionary mapping element IDs to element definitions
+    """
+    with open(POM_DIR / 'elements.json', 'r') as f:
+        data = json.load(f)
+    return {elem['id']: elem for elem in data.get('elements', [])}
+
+
+def load_obsidian_operations() -> dict:
+    """
+    Load Obsidian operations for inspection (no driver needed).
+
+    Returns:
+        Dictionary mapping operation names to operation definitions
+    """
+    with open(POM_DIR / 'operations.json', 'r') as f:
+        data = json.load(f)
+    return {op['name']: op for op in data.get('operations', [])}
+
+
+class ObsidianPage(BasePOM):
+    """
+    Page Object for Obsidian note-taking application.
+
+    Extends BasePOM with Obsidian-specific convenience methods.
+    All operations from operations.json are available as methods.
+
+    Example:
+        obsidian = ObsidianPage(driver)
+
+        # Navigate with quick switcher
+        obsidian.open_quick_switcher()
+        obsidian.search_note("My Note")
+        obsidian.select_first_result()
+
+        # Create content
+        obsidian.create_new_note()
+        obsidian.type_in_editor("# My Heading")
+    """
+
+    def __init__(self, driver: WebDriver, timeout: float = 10.0):
+        """
+        Initialize Obsidian Page Object.
+
+        Args:
+            driver: WebDriver instance connected to Obsidian
+            timeout: Default wait timeout in seconds
+        """
+        pom_data = POMData('Obsidian', POM_DIR).load()
+        super().__init__(driver, pom_data, timeout)
+
+        # Switch to main Obsidian window
+        self._switch_to_obsidian_window()
+
+    def _switch_to_obsidian_window(self) -> None:
+        """Switch to the main Obsidian window."""
+        for handle in self._driver.window_handles:
+            self._driver.switch_to.window(handle)
+            if 'Obsidian' in self._driver.title:
+                return
+        if self._driver.window_handles:
+            self._driver.switch_to.window(self._driver.window_handles[-1])
+
+    # =========================================
+    # Convenience Methods
+    # =========================================
+
+    def search_note(self, note_name: str, open_note: bool = True) -> None:
+        """
+        Search for and optionally open a note using quick switcher.
+
+        Args:
+            note_name: Name of the note to search for
+            open_note: Whether to open the first result
+        """
+        self.open_quick_switcher()
+        time.sleep(0.3)
+
+        # Type in the switcher
+        self.search_in_switcher(text=note_name)
+        time.sleep(0.3)
+
+        if open_note:
+            self.select_first_result()
+            time.sleep(0.3)
+
+    def run_command(self, command_name: str) -> None:
+        """
+        Run a command by name using the command palette.
+
+        Args:
+            command_name: Name of the command to run
+        """
+        self.open_command_palette()
+        time.sleep(0.3)
+
+        # Type in palette
+        try:
+            input_el = self._driver.find_element(By.CSS_SELECTOR, '.prompt input')
+            input_el.clear()
+            input_el.send_keys(command_name)
+            time.sleep(0.3)
+            input_el.send_keys(Keys.ENTER)
+        except Exception:
+            pass
+
+    def type_in_editor(self, text: str) -> None:
+        """
+        Type text into the active editor.
+
+        Args:
+            text: Text to type
+        """
+        editor = self.find_element('editor')
+        if editor:
+            editor.click()
+            ActionChains(self._driver).send_keys(text).perform()
+
+    def get_open_tabs(self) -> List[str]:
+        """
+        Get list of open tab names.
+
+        Returns:
+            List of tab titles
+        """
+        tabs = self._driver.find_elements(By.CSS_SELECTOR, '.workspace-tab-header.tappable')
+        return [tab.get_attribute('aria-label') or tab.text for tab in tabs]
+
+    def get_active_tab(self) -> Optional[str]:
+        """
+        Get the name of the currently active tab.
+
+        Returns:
+            Active tab name or None
+        """
+        try:
+            active = self._driver.find_element(
+                By.CSS_SELECTOR, '.workspace-tab-header.is-active, .workspace-tab-header.mod-active'
+            )
+            return active.get_attribute('aria-label') or active.text
+        except Exception:
+            return None
+
+    def switch_to_tab(self, tab_name: str) -> bool:
+        """
+        Switch to a tab by name.
+
+        Args:
+            tab_name: Name of the tab to switch to
+
+        Returns:
+            True if tab was found and clicked
+        """
+        tabs = self._driver.find_elements(By.CSS_SELECTOR, '.workspace-tab-header.tappable')
+        for tab in tabs:
+            label = tab.get_attribute('aria-label') or tab.text
+            if label == tab_name:
+                tab.click()
+                return True
+        return False
+
+    def get_file_list(self) -> List[str]:
+        """
+        Get list of files in the file explorer.
+
+        Returns:
+            List of file names
+        """
+        files = self._driver.find_elements(By.CSS_SELECTOR, '.nav-file-title')
+        return [f.text for f in files]
+
+    def open_file(self, filename: str) -> bool:
+        """
+        Open a file from the file explorer.
+
+        Args:
+            filename: Name of the file to open
+
+        Returns:
+            True if file was found and clicked
+        """
+        files = self._driver.find_elements(By.CSS_SELECTOR, '.nav-file-title')
+        for f in files:
+            if f.text == filename:
+                ActionChains(self._driver).double_click(f).perform()
+                return True
+        return False
+
+    def is_modal_open(self) -> bool:
+        """Check if any modal (like quick switcher) is open."""
+        try:
+            modal = self._driver.find_element(By.CSS_SELECTOR, '.prompt')
+            return modal.is_displayed()
+        except Exception:
+            return False
+
+    def get_ribbon_actions(self) -> List[str]:
+        """
+        Get list of available ribbon actions.
+
+        Returns:
+            List of ribbon action labels
+        """
+        actions = self._driver.find_elements(By.CSS_SELECTOR, '.side-dock-ribbon-action')
+        return [a.get_attribute('aria-label') or '' for a in actions if a.get_attribute('aria-label')]
+
+    def click_ribbon_action(self, label: str) -> bool:
+        """
+        Click a ribbon action by its label.
+
+        Args:
+            label: Aria-label of the ribbon action
+
+        Returns:
+            True if action was found and clicked
+        """
+        try:
+            action = self._driver.find_element(By.CSS_SELECTOR, f'[aria-label="{label}"]')
+            action.click()
+            return True
+        except Exception:
+            return False
+
+
+# Convenience function for quick loading
+def load(driver: WebDriver, timeout: float = 10.0) -> ObsidianPage:
+    """
+    Quick loader for ObsidianPage.
+
+    Usage:
+        from poms.Obsidian import obsidian_page
+        obsidian = obsidian_page.load(driver)
+    """
+    return ObsidianPage(driver, timeout)

--- a/poms/Obsidian/operations.json
+++ b/poms/Obsidian/operations.json
@@ -1,0 +1,227 @@
+{
+  "app_name": "Obsidian",
+  "version": "1.0.0",
+  "operations": [
+    {
+      "name": "create_new_note",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Create a new note (Cmd+N)",
+      "shortcut_keys": ["COMMAND", "n"],
+      "wait_after": 0.5
+    },
+    {
+      "name": "create_new_canvas",
+      "element_id": "create_new_canvas",
+      "action": "click",
+      "description": "Create a new canvas",
+      "wait_after": 0.5
+    },
+    {
+      "name": "create_new_board",
+      "element_id": "create_new_board",
+      "action": "click",
+      "description": "Create a new Kanban board",
+      "wait_after": 0.5
+    },
+    {
+      "name": "create_unique_note",
+      "element_id": "create_unique_note",
+      "action": "click",
+      "description": "Create a new unique note",
+      "wait_after": 0.5
+    },
+    {
+      "name": "insert_template",
+      "element_id": "insert_template",
+      "action": "click",
+      "description": "Insert a template into current note",
+      "wait_after": 0.3
+    },
+    {
+      "name": "create_new_tab",
+      "element_id": "new_tab",
+      "action": "click",
+      "description": "Create a new tab",
+      "wait_after": 0.3
+    },
+    {
+      "name": "open_quick_switcher",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open the quick switcher (Cmd+O)",
+      "shortcut_keys": ["COMMAND", "o"],
+      "wait_after": 0.3,
+      "post_condition": "lambda driver: driver.find_elements(By.CSS_SELECTOR, '.prompt')"
+    },
+    {
+      "name": "open_command_palette",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open the command palette (Cmd+P)",
+      "shortcut_keys": ["COMMAND", "p"],
+      "wait_after": 0.3,
+      "post_condition": "lambda driver: driver.find_elements(By.CSS_SELECTOR, '.prompt')"
+    },
+    {
+      "name": "close_modal",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Close current modal (Escape)",
+      "shortcut_keys": ["ESCAPE"],
+      "wait_after": 0.2
+    },
+    {
+      "name": "open_graph_view",
+      "element_id": "graph_view",
+      "action": "click",
+      "description": "Open the graph view",
+      "wait_after": 0.5
+    },
+    {
+      "name": "open_daily_note",
+      "element_id": "daily_note",
+      "action": "click",
+      "description": "Open today's daily note",
+      "wait_after": 0.5
+    },
+    {
+      "name": "open_smart_connections",
+      "element_id": "smart_connections",
+      "action": "click",
+      "description": "Open Smart Connections view",
+      "wait_after": 0.3
+    },
+    {
+      "name": "open_smart_lookup",
+      "element_id": "smart_lookup",
+      "action": "click",
+      "description": "Open Smart Lookup view",
+      "wait_after": 0.3
+    },
+    {
+      "name": "navigate_back",
+      "element_id": "navigate_back",
+      "action": "click",
+      "description": "Navigate back in history"
+    },
+    {
+      "name": "navigate_forward",
+      "element_id": "navigate_forward",
+      "action": "click",
+      "description": "Navigate forward in history"
+    },
+    {
+      "name": "go_back_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Navigate back via keyboard (Cmd+[)",
+      "shortcut_keys": ["COMMAND", "["]
+    },
+    {
+      "name": "go_forward_shortcut",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Navigate forward via keyboard (Cmd+])",
+      "shortcut_keys": ["COMMAND", "]"]
+    },
+    {
+      "name": "open_files_panel",
+      "element_id": "files_tab",
+      "action": "click",
+      "description": "Open the Files panel"
+    },
+    {
+      "name": "open_search_panel",
+      "element_id": "search_tab",
+      "action": "click",
+      "description": "Open the Search panel"
+    },
+    {
+      "name": "open_bookmarks_panel",
+      "element_id": "bookmarks_tab",
+      "action": "click",
+      "description": "Open the Bookmarks panel"
+    },
+    {
+      "name": "open_backlinks_panel",
+      "element_id": "backlinks_tab",
+      "action": "click",
+      "description": "Open the Backlinks panel"
+    },
+    {
+      "name": "open_tags_panel",
+      "element_id": "tags_tab",
+      "action": "click",
+      "description": "Open the Tags panel"
+    },
+    {
+      "name": "publish_changes",
+      "element_id": "publish_changes",
+      "action": "click",
+      "description": "Open the publish changes dialog"
+    },
+    {
+      "name": "open_more_options",
+      "element_id": "more_options",
+      "action": "click",
+      "description": "Open the more options menu"
+    },
+    {
+      "name": "change_sort_order",
+      "element_id": "change_sort_order",
+      "action": "click",
+      "description": "Open sort order options"
+    },
+    {
+      "name": "open_settings",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Open settings (Cmd+,)",
+      "shortcut_keys": ["COMMAND", ","],
+      "wait_after": 0.5
+    },
+    {
+      "name": "toggle_left_sidebar",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Toggle left sidebar (Cmd+\\)",
+      "shortcut_keys": ["COMMAND", "\\"]
+    },
+    {
+      "name": "search_in_switcher",
+      "element_id": "quick_switcher_input",
+      "action": "clear_and_type",
+      "description": "Type search query in quick switcher",
+      "params": {"text": ""}
+    },
+    {
+      "name": "select_first_result",
+      "element_id": "",
+      "action": "shortcut",
+      "description": "Select first search result (Enter)",
+      "shortcut_keys": ["ENTER"]
+    },
+    {
+      "name": "wait_page_load",
+      "element_id": "app_container",
+      "action": "wait_visible",
+      "description": "Wait for Obsidian to load",
+      "params": {"timeout": 10.0}
+    },
+    {
+      "name": "wait_modal_appear",
+      "element_id": "quick_switcher_modal",
+      "action": "wait_visible",
+      "description": "Wait for modal to appear",
+      "params": {"timeout": 5.0}
+    },
+    {
+      "name": "wait_modal_disappear",
+      "element_id": "quick_switcher_modal",
+      "action": "wait_invisible",
+      "description": "Wait for modal to disappear",
+      "params": {"timeout": 5.0}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

JSON-based Page Object Models with Python wrappers for each supported app:

### Claude/
- `elements.json`: Chat, sidebar, settings elements
- `operations.json`: Send message, new conversation, etc.
- `claude_page.py`: ClaudePage wrapper with convenience methods

### Cursor/
- `elements.json`: Editor, tabs, AI pane, terminal elements
- `operations.json`: Open file, run command, toggle panels
- `cursor_page.py`: CursorPage wrapper with IDE-specific methods

### Obsidian/
- `elements.json`: Note, sidebar, vault elements
- `operations.json`: Create note, search, navigate
- `obsidian_page.py`: ObsidianPage wrapper with note-taking methods

## Test plan

- [ ] POMs load without errors
- [ ] Elements can be found using definitions
- [ ] Operations execute correctly
- [ ] Wrappers provide working convenience methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)